### PR TITLE
Add npm run deps task

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "node_modules/.bin/jshint --verbose *.js build/*.js lib/*.js test/*.js && node_modules/.bin/mocha",
     "browserify": "mkdir -p ./dist/ && browserify ./lib/browser_main.js -o ./dist/browser_package.js",
     "serve": "npm run browserify && node serve.js",
-    "deps": "npm install && cd test/bower_0.5 && bower install && cd ../bower_1.0 && bower install"
+    "deps": "npm install && bower install && cd test/bower_0.5 && bower install && cd ../bower_1.0 && bower install"
   },
   "keywords": [
     "polymer"


### PR DESCRIPTION
I tripped up trying to get the tests running and only noticed after that we're expected to install Bower deps in two specific directories. This PR enables `npm run deps` to both install your npm deps and all Bower deps required.
