### PR TITLE
Gather all element metadata before upgrading scripts.

### DIFF
--- a/lib/upgrade_html.js
+++ b/lib/upgrade_html.js
@@ -27,7 +27,6 @@ var Set = es6Collections.Set || global.Set;
 var Map = es6Collections.Map || global.Map;
 // jshint +W079
 
-
 class Page {
   constructor(filename, options={}) {
     this.filename = path.resolve(filename);
@@ -35,6 +34,8 @@ class Page {
     this.modified = false;
     this.results = {};
     this.upgradedScriptElems = new Set();
+    this.elements = new Map();
+    this.scriptElementsToCustomElements = new Map();
   }
 
   /** The main function */
@@ -53,6 +54,13 @@ class Page {
     this.$('polymer-element').each((_ignored, polyElem) => {
       this.modified = true;
       var elemName = polyElem.attribs.name;
+      var elementMetadata = {
+        name: elemName,
+        attrs: {},
+        hostAttrs: {},
+        newDeclarations: []
+      };
+      this.elements.set(elemName, elementMetadata);
 
       var domModule = this.$('<dom-module>');
       domModule.attr('id', elemName);
@@ -86,14 +94,14 @@ class Page {
 
       // The properties that are listed in the 'attributes' attribute are
       // published by default. The js upgrade will want to know about this.
-      var attrs = {};
+      elementMetadata.attrs = {};
       if (polyElem.attribs.attributes) {
         polyElem.attribs.attributes.split(/\s+/).forEach(
           (publishedAttrName) => {
             if (!publishedAttrName) {
               return;
             }
-            attrs[publishedAttrName] = {
+            elementMetadata.attrs[publishedAttrName] = {
               name: publishedAttrName,
               notify: { type: 'Literal', value: true}
             };
@@ -101,22 +109,19 @@ class Page {
         );
       }
 
-      var newDeclarations = [];
-
       // Unknown attributes are probably intended to be published with
       // hostAttributes
-      var hostAttrs = {};
       var knownAttributes = ['name', 'attributes', 'noscript', 'extends', 'id'];
       for (var attr in polyElem.attribs) {
         if (_.contains(knownAttributes, attr)) {
           continue;
         }
-        hostAttrs[attr] = polyElem.attribs[attr];
+        elementMetadata.hostAttrs[attr] = polyElem.attribs[attr];
       }
 
 
       if ('extends' in polyElem.attribs) {
-        newDeclarations.push({
+        elementMetadata.newDeclarations.push({
             type: 'Property',
             key: {type: 'Identifier', name: 'extends'},
             value: {type: 'Literal', value: polyElem.attribs.extends}
@@ -138,15 +143,13 @@ class Page {
         this.$(polyElem).append(newScript);
       }
 
-      this.upgradeDataBoundTemplate(template, newDeclarations);
+      this.upgradeDataBoundTemplate(template, elementMetadata.newDeclarations);
 
       // Upgrade the js
       this.$('script', polyElem).each((_ignored, scriptElem) => {
+        this.scriptElementsToCustomElements.set(scriptElem, elemName);
         // Move the script after the polymer-element.
         this.$(polyElem).after(scriptElem);
-        this.upgradedScriptElems.add(scriptElem);
-        this.upgradeScriptElement(
-            scriptElem, attrs, hostAttrs, elemName, newDeclarations);
       });
 
       // Replace the <polymer-element> with our shiny new <dom-module>
@@ -171,7 +174,8 @@ class Page {
       if (this.upgradedScriptElems.has(scriptElem)) {
         return;
       }
-      this.upgradeScriptElement(scriptElem);
+      this.upgradeScriptElement(
+          scriptElem, this.scriptElementsToCustomElements.get(scriptElem));
     });
 
     // Upgrade official polymer elements using the mappings in element_mapping.js
@@ -474,31 +478,15 @@ class Page {
    * is inline and has been upgraded in place.
    *
    * @param {string} docFilename The absolute path to the containing document.
-   * @param {ScriptElement} scriptElem The <script> element to modify.
-   * @param {?Object<string, Object>} attrs The attributes of the
-   *    <polymer-element> that contains this script, if any.
-   * @param {?Object<string, Object>} hostAttrs The hostAttributes of the
-   *    <polymer-element> that contains this script, if any.
-   * @param {?string} elemName The name of the <polymer-element> that contains
-   *    this script, if any.
-   * @param {Array<PropertyAst>} A list of new properties to add to the Polymer()
-   *    declaration that corresponds to elemName.
+   * @param {?string} implicitElemName The name of the <polymer-element> that
+   *    contains this script, if any.
    * @return {?Array<string>}
    */
-  upgradeScriptElement(scriptElem, attrs,
-                       hostAttrs, elemName, newDeclarations) {
+  upgradeScriptElement(scriptElem, implicitElemName) {
     // TODO(rictic): we should be tracking element metadata across the entire
     //     page, then upgrade all javascript, passing in all of the metadata in.
     //     This will solve a bug with multiple calls to Polymer() in not getting
     //     element metadata populated properly.
-    var elements = new Map();
-    if (elemName) {
-      elements.set(elemName, {
-        attrs: attrs,
-        hostAttrs: hostAttrs,
-        newDeclarations: newDeclarations
-      });
-    }
 
     if ('src' in scriptElem.attribs) {
       let srcPath = scriptElem.attribs.src;
@@ -516,13 +504,14 @@ class Page {
         console.warn('Warning: unable to read script source for ' + srcPath);
         return;
       }
-      let upgradedJs = upgradeJs(scriptSource, elements, elemName, 0);
+      let upgradedJs = upgradeJs(
+          scriptSource, this.elements, implicitElemName, 0);
       if (upgradedJs) {
         this.results[pathToScriptElem] = upgradedJs + '\n';
       }
     } else {
       let upgradedJs = upgradeJs(
-          this.$(scriptElem).text(), elements, elemName, 1);
+          this.$(scriptElem).text(), this.elements, implicitElemName, 1);
       if (upgradedJs) {
         this.modified = true;
         this.$(scriptElem).text('\n' + upgradedJs + '\n');

--- a/lib/upgrade_js.js
+++ b/lib/upgrade_js.js
@@ -22,14 +22,16 @@ var Set = es6Collections.Set || global.Set;
 // jshint +W079
 
 class Script {
-  constructor(jsSource, elements, initialIndent) {
+  constructor(jsSource, elements, initialIndent, implicitElemName) {
     this.jsSource = jsSource;
     this.elements = elements;
     this.initialIndent = initialIndent;
     this.modified = false;
+    this.implicitElemName = implicitElemName;
+    this.implicitElemNameUsed = false;
   }
 
-  upgrade(implicitElemName) {
+  upgrade() {
     this.ast = espree.parse(this.jsSource, {attachComment: true});
 
     var polymerCalls = [];
@@ -41,169 +43,7 @@ class Script {
       }
     });
 
-    var implicitNameUsed = false;
-
-    polymerCalls.forEach((polyCall) => {
-      this.modified = true;
-      var name = extractExplicitElementNameFromPolymerCall(polyCall);
-      var attrs = {};
-      var hostAttrs = {};
-      var behaviors = [];
-      var newDeclarations = [];
-      if (name == null) {
-        if (implicitElemName == null) {
-          throw new Error('Unable to determine element name in javascript. ' +
-              'No matching <polymer-element> found, nor was an explicit name ' +
-              'given.');
-        }
-        if (implicitNameUsed) {
-          throw new Error('Unable to determine element name in javascript. ' +
-              'Multiple calls to Polymer() found without an explicit element ' +
-              'name.');
-        }
-        name = implicitElemName;
-      }
-      if (this.elements.has(name)) {
-        var elementInfo = this.elements.get(name);
-        attrs = elementInfo.attrs || attrs;
-        hostAttrs = elementInfo.hostAttrs || hostAttrs;
-        newDeclarations = elementInfo.newDeclarations || newDeclarations;
-      }
-
-      var declaration = polyCall.arguments[0];
-      if (declaration == null) {
-        declaration = {type: 'ObjectExpression', properties: []};
-        polyCall.arguments.push(declaration);
-      }
-
-      while (declaration.type === 'CallExpression') {
-        // If the call expression is Polymer.mixin or Polymer.mixin2
-        if (declaration.callee.type === 'MemberExpression') {
-          var memberExpr = declaration.callee;
-          if (memberExpr.object.name === 'Polymer' &&
-              _.contains(['mixin', 'mixin2'], memberExpr.property.name)) {
-            var mixin = declaration.arguments[1];
-            declaration = declaration.arguments[0];
-            polyCall.arguments[0] = declaration;
-            behaviors.push(mixin);
-          }
-        }
-      }
-      if (declaration.type != 'ObjectExpression') {
-        throw new Error(
-            "Unexpected kind of thing passed to Polymer() - " +
-            declaration.type);
-      }
-
-      // Create a 'properties' block with all of the properties we've extracted
-      // from various places (the 'attributes' attribute, computed properties,
-      // observed properties, default values, etc etc).
-      migrateAttributesToPropertiesBlock(polyCall, declaration, attrs);
-
-      // hostAttributes
-      var hostAttrsProperties = [];
-      for (var key in hostAttrs) {
-        var astVal = {type: 'Literal', value: hostAttrs[key]};
-        if (astVal.value === 'true') {
-          astVal.value = true;
-        }
-        hostAttrsProperties.push({
-          type: 'Property',
-          key: {type: 'Identifier', name: key},
-          value: astVal
-        });
-      }
-      if (hostAttrsProperties.length > 0) {
-        declaration.properties.push({
-          type: 'Property',
-          key: {type: 'Identifier', name: 'hostAttributes'},
-          value: {
-            type: 'ObjectExpression',
-            properties: hostAttrsProperties
-          }
-        });
-      }
-
-      // Add behaviors
-      if (behaviors.length > 0) {
-        declaration.properties.unshift(getBehaviorsDeclaration(behaviors));
-      }
-
-      // Add the is: 'my-elem' property
-      declaration.properties.unshift({
-        type: 'Property',
-        key: { type: 'Identifier', name: 'is'},
-        value: { type: 'Literal', value: name}
-      });
-
-      // domReady -> ready
-      var domReadyBody = null;
-      declaration.properties.forEach(function(prop) {
-        if (getPropertyKeyName(prop) != 'domReady') {
-          return;
-        }
-        if (prop.value.type !== 'FunctionExpression') {
-          throw new Error(
-              'Expected the value of the `domReady` property to ' +
-              'be a function expression.');
-        }
-        domReadyBody = prop.value.body.body;
-      });
-      if (domReadyBody != null) {
-        var readyBody = null;
-        declaration.properties.forEach(function(prop) {
-          if (getPropertyKeyName(prop) != 'ready') {
-            return;
-          }
-          if (prop.value.type !== 'FunctionExpression') {
-            throw new Error(
-                'Expected the value of the `ready` property to ' +
-                'be a function expression.');
-          }
-          readyBody = prop.value.body.body;
-        });
-
-        if (readyBody == null) {
-          readyBody = [];
-          declaration.properties.push({
-            type: 'Property',
-            key: {type: 'Identifier', name: 'ready'},
-            value: {type: 'FunctionExpression', params: [], body: {
-              type: 'BlockStatement',
-              body: readyBody
-            }}
-          });
-        }
-        domReadyBody.forEach(function(expr) {
-          readyBody.push(expr);
-        });
-      }
-      declaration.properties = declaration.properties.filter(function(prop) {
-        return getPropertyKeyName(prop) != 'domReady';});
-
-      var thisMethodRenames = {
-        job: 'debounce',
-        resolvePath: 'resolveUrl'
-      };
-      estree_walker.walk(declaration, {
-        enter: function(node) {
-
-          if (node.type === 'CallExpression') {
-            // this.job -> this.debounce and friends
-            if (node.callee.type === 'MemberExpression' &&
-                node.callee.object.type === 'ThisExpression' &&
-                node.callee.property.name in thisMethodRenames) {
-              node.callee.property.name = thisMethodRenames[
-                  node.callee.property.name];
-            }
-          }
-        }
-      });
-
-      newDeclarations.forEach(function(decl) {
-        declaration.properties.push(decl);
-      });
-    });
+    polymerCalls.forEach(this.upgradePolymerCall.bind(this));
 
     if (!this.modified) {
       return null;
@@ -220,12 +60,176 @@ class Script {
       }
     });
   }
+
+  /**
+   * Upgrade a single Polymer() call.
+   */
+  upgradePolymerCall(polyCall) {
+    this.modified = true;
+    var name = extractExplicitElementNameFromPolymerCall(polyCall);
+    var attrs = {};
+    var hostAttrs = {};
+    var behaviors = [];
+    var newDeclarations = [];
+    if (name == null) {
+      if (this.implicitElemName == null) {
+        throw new Error('Unable to determine element name in javascript. ' +
+            'No matching <polymer-element> found, nor was an explicit name ' +
+            'given.');
+      }
+      if (this.implicitElemNameUsed) {
+        throw new Error('Unable to determine element name in javascript. ' +
+            'Multiple calls to Polymer() found without an explicit element ' +
+            'name.');
+      }
+      name = this.implicitElemName;
+    }
+    if (this.elements.has(name)) {
+      var elementInfo = this.elements.get(name);
+      attrs = elementInfo.attrs || attrs;
+      hostAttrs = elementInfo.hostAttrs || hostAttrs;
+      newDeclarations = elementInfo.newDeclarations || newDeclarations;
+    }
+
+    var declaration = polyCall.arguments[0];
+    if (declaration == null) {
+      declaration = {type: 'ObjectExpression', properties: []};
+      polyCall.arguments.push(declaration);
+    }
+
+    while (declaration.type === 'CallExpression') {
+      // If the call expression is Polymer.mixin or Polymer.mixin2
+      if (declaration.callee.type === 'MemberExpression') {
+        var memberExpr = declaration.callee;
+        if (memberExpr.object.name === 'Polymer' &&
+            _.contains(['mixin', 'mixin2'], memberExpr.property.name)) {
+          var mixin = declaration.arguments[1];
+          declaration = declaration.arguments[0];
+          polyCall.arguments[0] = declaration;
+          behaviors.push(mixin);
+        }
+      }
+    }
+    if (declaration.type != 'ObjectExpression') {
+      throw new Error(
+          "Unexpected kind of thing passed to Polymer() - " +
+          declaration.type);
+    }
+
+    // Create a 'properties' block with all of the properties we've extracted
+    // from various places (the 'attributes' attribute, computed properties,
+    // observed properties, default values, etc etc).
+    migrateAttributesToPropertiesBlock(polyCall, declaration, attrs);
+
+    // hostAttributes
+    var hostAttrsProperties = [];
+    for (var key in hostAttrs) {
+      var astVal = {type: 'Literal', value: hostAttrs[key]};
+      if (astVal.value === 'true') {
+        astVal.value = true;
+      }
+      hostAttrsProperties.push({
+        type: 'Property',
+        key: {type: 'Identifier', name: key},
+        value: astVal
+      });
+    }
+    if (hostAttrsProperties.length > 0) {
+      declaration.properties.push({
+        type: 'Property',
+        key: {type: 'Identifier', name: 'hostAttributes'},
+        value: {
+          type: 'ObjectExpression',
+          properties: hostAttrsProperties
+        }
+      });
+    }
+
+    // Add behaviors
+    if (behaviors.length > 0) {
+      declaration.properties.unshift(getBehaviorsDeclaration(behaviors));
+    }
+
+    // Add the is: 'my-elem' property
+    declaration.properties.unshift({
+      type: 'Property',
+      key: { type: 'Identifier', name: 'is'},
+      value: { type: 'Literal', value: name}
+    });
+
+    // domReady -> ready
+    var domReadyBody = null;
+    declaration.properties.forEach(function(prop) {
+      if (getPropertyKeyName(prop) != 'domReady') {
+        return;
+      }
+      if (prop.value.type !== 'FunctionExpression') {
+        throw new Error(
+            'Expected the value of the `domReady` property to ' +
+            'be a function expression.');
+      }
+      domReadyBody = prop.value.body.body;
+    });
+    if (domReadyBody != null) {
+      var readyBody = null;
+      declaration.properties.forEach(function(prop) {
+        if (getPropertyKeyName(prop) != 'ready') {
+          return;
+        }
+        if (prop.value.type !== 'FunctionExpression') {
+          throw new Error(
+              'Expected the value of the `ready` property to ' +
+              'be a function expression.');
+        }
+        readyBody = prop.value.body.body;
+      });
+
+      if (readyBody == null) {
+        readyBody = [];
+        declaration.properties.push({
+          type: 'Property',
+          key: {type: 'Identifier', name: 'ready'},
+          value: {type: 'FunctionExpression', params: [], body: {
+            type: 'BlockStatement',
+            body: readyBody
+          }}
+        });
+      }
+      domReadyBody.forEach(function(expr) {
+        readyBody.push(expr);
+      });
+    }
+    declaration.properties = declaration.properties.filter(function(prop) {
+      return getPropertyKeyName(prop) != 'domReady';});
+
+    var thisMethodRenames = {
+      job: 'debounce',
+      resolvePath: 'resolveUrl'
+    };
+    estree_walker.walk(declaration, {
+      enter: function(node) {
+
+        if (node.type === 'CallExpression') {
+          // this.job -> this.debounce and friends
+          if (node.callee.type === 'MemberExpression' &&
+              node.callee.object.type === 'ThisExpression' &&
+              node.callee.property.name in thisMethodRenames) {
+            node.callee.property.name = thisMethodRenames[
+                node.callee.property.name];
+          }
+        }
+      }
+    });
+
+    newDeclarations.forEach(function(decl) {
+      declaration.properties.push(decl);
+    });
+  }
 }
 
 function upgradeJs(jsSource, elements, implicitElemName=null, initialIndent=0) {
-  var script = new Script(jsSource, elements, initialIndent);
-
-  return script.upgrade(implicitElemName);
+  var script = new Script(jsSource, elements, initialIndent, implicitElemName);
+  return script.upgrade();
 }
 
 

--- a/test/fixtures/multiple-elements-one-script.html
+++ b/test/fixtures/multiple-elements-one-script.html
@@ -1,0 +1,10 @@
+<link rel='import' href='../polymer/polymer.html'>
+
+<polymer-element name='elem-1' attributes='one'>
+</polymer-element>
+
+
+<polymer-element name='elem-2' attributes='two'>
+<script src='multiple-elements-one-script.js'></script>
+</polymer-element>
+

--- a/test/fixtures/multiple-elements-one-script.html.out
+++ b/test/fixtures/multiple-elements-one-script.html.out
@@ -1,0 +1,11 @@
+<link rel="import" href="../polymer/polymer.html">
+
+<dom-module id="elem-1">
+</dom-module>
+
+
+
+<dom-module id="elem-2">
+</dom-module>
+<script src="multiple-elements-one-script.js"></script>
+

--- a/test/fixtures/multiple-elements-one-script.js
+++ b/test/fixtures/multiple-elements-one-script.js
@@ -1,0 +1,3 @@
+Polymer({});
+
+Polymer('elem-1', {})

--- a/test/fixtures/multiple-elements-one-script.js.out
+++ b/test/fixtures/multiple-elements-one-script.js.out
@@ -1,0 +1,8 @@
+Polymer({
+  is: 'elem-2',
+  properties: { two: { notify: true } }
+});
+Polymer({
+  is: 'elem-1',
+  properties: { one: { notify: true } }
+});


### PR DESCRIPTION
Element metadata includes stuff like attributes, host attributes,
new computed functions. We need this metadata to build out the Polymer()
declaration for the element.

Before we were upgrading scripts more or less as we saw them, and not
keeping track of all element metadata in one place. Now, we first gather
all of the metadata, so that we'll be able to upgrade any Polymer() call
for any element in any <script>. The most common real world case that this
improves is when a script contains more than one call to Polymer().
