### PR TITLE
Distinguish host attributes from listeners.

### DIFF
--- a/lib/upgrade_html.js
+++ b/lib/upgrade_html.js
@@ -58,6 +58,7 @@ class Page {
         name: elemName,
         attrs: {},
         hostAttrs: {},
+        listeners: {},
         newDeclarations: []
       };
       this.elements.set(elemName, elementMetadata);
@@ -109,14 +110,25 @@ class Page {
         );
       }
 
-      // Unknown attributes are probably intended to be published with
-      // hostAttributes
+      // Unknown attributes are either listeners, or they're probably intended
+      // to be published with hostAttributes.
       var knownAttributes = ['name', 'attributes', 'noscript', 'extends', 'id'];
       for (var attr in polyElem.attribs) {
         if (_.contains(knownAttributes, attr)) {
           continue;
         }
-        elementMetadata.hostAttrs[attr] = polyElem.attribs[attr];
+        var match = attr.match(/^on-(.*)$/);
+        if (match) {
+          var eventName = match[1];
+          var listenerFuncExpr = polyElem.attribs[attr];
+          match = listenerFuncExpr.match(/^\{\{(.*)\}\}$/);
+          if (match) {
+            listenerFuncExpr = match[1];
+          }
+          elementMetadata.listeners[eventName] = listenerFuncExpr;
+        } else {
+          elementMetadata.hostAttrs[attr] = polyElem.attribs[attr];
+        }
       }
 
 

--- a/lib/upgrade_html.js
+++ b/lib/upgrade_html.js
@@ -121,9 +121,9 @@ class Page {
         if (match) {
           var eventName = match[1];
           var listenerFuncExpr = polyElem.attribs[attr];
-          match = listenerFuncExpr.match(/^\{\{(.*)\}\}$/);
+          match = listenerFuncExpr.match(/^(\{\{|\[\[)(.*)(\}\}|\]\])$/);
           if (match) {
-            listenerFuncExpr = match[1];
+            listenerFuncExpr = match[2];
           }
           elementMetadata.listeners[eventName] = listenerFuncExpr;
         } else {

--- a/lib/upgrade_js.js
+++ b/lib/upgrade_js.js
@@ -70,6 +70,7 @@ class Script {
     var attrs = {};
     var hostAttrs = {};
     var behaviors = [];
+    var listeners = {};
     var newDeclarations = [];
     if (name == null) {
       if (this.implicitElemName == null) {
@@ -89,6 +90,7 @@ class Script {
       attrs = elementInfo.attrs || attrs;
       hostAttrs = elementInfo.hostAttrs || hostAttrs;
       newDeclarations = elementInfo.newDeclarations || newDeclarations;
+      listeners = elementInfo.listeners || listeners;
     }
 
     var declaration = polyCall.arguments[0];
@@ -123,8 +125,8 @@ class Script {
 
     // hostAttributes
     var hostAttrsProperties = [];
-    for (var key in hostAttrs) {
-      var astVal = {type: 'Literal', value: hostAttrs[key]};
+    for (let key in hostAttrs) {
+      let astVal = {type: 'Literal', value: hostAttrs[key]};
       if (astVal.value === 'true') {
         astVal.value = true;
       }
@@ -141,6 +143,25 @@ class Script {
         value: {
           type: 'ObjectExpression',
           properties: hostAttrsProperties
+        }
+      });
+    }
+
+    var listenerProperties = [];
+    for (let key in listeners) {
+      listenerProperties.push({
+        type: 'Property',
+        key: {type: 'Identifier', name: key},
+        value: {type: 'Literal', value: listeners[key]}
+      });
+    }
+    if (listenerProperties.length > 0) {
+      declaration.properties.push({
+        type: 'Property',
+        key: {type: 'Identifier', name: 'listeners'},
+        value: {
+          type: 'ObjectExpression',
+          properties: listenerProperties
         }
       });
     }

--- a/test/fixtures/more-attributes.html
+++ b/test/fixtures/more-attributes.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 
-<polymer-element name="attributes-element" attributes="a b c">
+<polymer-element name="attributes-element" attributes="a b c"
+                 x="1" y="2" on-scroll='{{scrollFunc}}'>
   <script>
     Polymer({
       a: 10,

--- a/test/fixtures/more-attributes.html.out
+++ b/test/fixtures/more-attributes.html.out
@@ -37,6 +37,11 @@
     },
     computeJ: function (b, c, h) {
       return this.callOk(b, c + h);
-    }
+    },
+    hostAttributes: {
+      x: '1',
+      y: '2'
+    },
+    listeners: { scroll: 'scrollFunc' }
   });
 </script>


### PR DESCRIPTION
Migrate listeners out of on-\* attributes on <polymer-element>.

Fixes #20.
