### PR TITLE
Host attribute keys should be string literals.

### DIFF
--- a/lib/upgrade_js.js
+++ b/lib/upgrade_js.js
@@ -128,7 +128,7 @@ class Script {
       }
       hostAttrsProperties.push({
         type: 'Property',
-        key: {type: 'Identifier', name: key},
+        key: {type: 'Literal', value: key},
         value: astVal
       });
     }

--- a/test/fixtures/layout-attribs.html
+++ b/test/fixtures/layout-attribs.html
@@ -19,7 +19,7 @@
   <div>Right</div>
 </div>
 
-<polymer-element name='element-uses-layout' noscript layout vertical justified>
+<polymer-element name='element-uses-layout' noscript layout vertical around-justified>
   <template>
     <div>Top</div>
     <div layout horizontal justified>

--- a/test/fixtures/layout-attribs.html.out
+++ b/test/fixtures/layout-attribs.html.out
@@ -25,6 +25,9 @@
     [layout][vertical] {
       @apply(--layout-vertical);
     }
+    [layout][around-justified] {
+      @apply(--layout-around-justified);
+    }
   </style>
   <link rel="import" href="components/iron-flex-layout/iron-flex-layout.html">
 </head>
@@ -46,8 +49,8 @@
     :host[layout][vertical] {
       @apply(--layout-vertical);
     }
-    :host[layout][justified] {
-      @apply(--layout-justified);
+    :host[layout][around-justified] {
+      @apply(--layout-around-justified);
     }
     [layout] {
       @apply(--layout);
@@ -83,9 +86,9 @@
   Polymer({
     is: 'element-uses-layout',
     hostAttributes: {
-      layout: '',
-      vertical: '',
-      justified: ''
+      'layout': '',
+      'vertical': '',
+      'around-justified': ''
     }
   });
 </script>

--- a/test/fixtures/more-attributes.html.out
+++ b/test/fixtures/more-attributes.html.out
@@ -39,8 +39,8 @@
       return this.callOk(b, c + h);
     },
     hostAttributes: {
-      x: '1',
-      y: '2'
+      'x': '1',
+      'y': '2'
     },
     listeners: { scroll: 'scrollFunc' }
   });

--- a/test/fixtures/simple-element.html.out
+++ b/test/fixtures/simple-element.html.out
@@ -96,7 +96,7 @@
     computeUrl: function (intVal) {
       return '/api/v' + intVal + '/get';
     },
-    hostAttributes: { tabindex: '0' },
+    hostAttributes: { 'tabindex': '0' },
     computeStyle: function (strAttr) {
       return 'background-color: ' + strAttr + ';';
     },


### PR DESCRIPTION
Because host attributes can contain characters that are illegal in identifiers,
like hyphens.

Fixes #43
