### PR TITLE
Generated functions should have unique names.

### DIFF
--- a/lib/upgrade_html.js
+++ b/lib/upgrade_html.js
@@ -396,11 +396,20 @@ class Page {
           attrName += '$';
           node.attribs[attrName] = tempVal;
         }
-        let [newExpression, newDeclaration] = upgradeJs.fixupComputedExpression(
-              attrName, expression);
+
+        const [namer, newDeclaration] = upgradeJs.fixupComputedExpression(
+              expression);
         addNewDeclaration(newDeclaration, expression, node);
-        if (newDeclarations) {
-          node.attribs[attrName] = `{{${newExpression}}}`;
+        if (newDeclarations && newDeclaration) {
+          newDeclaration.rename = (newName) => {
+            const newExpression = namer(newName);
+            node.attribs[attrName] = `{{${newExpression}}}`;
+          };
+          let computedFunctionName = 'compute' +
+              attrName.charAt(0).toUpperCase() + attrName.substring(1);
+          computedFunctionName = computedFunctionName.replace(
+              '$', '').replace('?', '');
+          newDeclaration.rename(computedFunctionName);
         } else {
           node.attribs[attrName] = `{{${expression}}}`;
         }
@@ -421,12 +430,18 @@ class Page {
       // Fixup all of the expressions we found.
       for (let piece of pieces) {
         if ('expression' in piece) {
-          let [newExpression, newDeclaration] =
-              upgradeJs.fixupComputedExpression(
-                    'Expression' + (counter++), piece.expression);
-          addNewDeclaration(newDeclaration, piece.expression, textNode.parent);
-          if (newDeclarations) {
-            piece.expression = newExpression;
+          const [namer, newDeclaration] =
+              upgradeJs.fixupComputedExpression(piece.expression);
+          if (newDeclaration) {
+            newDeclaration.rename = (newName) => {
+              const newExpression = namer(newName);
+              if (newDeclarations) {
+                piece.expression = newExpression;
+              }
+            };
+            newDeclaration.rename('computeExpression' + (counter++));
+            addNewDeclaration(
+                newDeclaration, piece.expression, textNode.parent);
           }
         }
       }

--- a/lib/upgrade_js.js
+++ b/lib/upgrade_js.js
@@ -238,7 +238,24 @@ class Script {
       }
     });
 
+    const declarationNames = new Set();
+    const getDeclName = (decl) => decl.key.name || decl.key.value;
+    for (let decl of declaration.properties) {
+      declarationNames.add(getDeclName(decl));
+    }
     newDeclarations.forEach(function(decl) {
+      while(decl.rename && declarationNames.has(getDeclName(decl))) {
+        let name = getDeclName(decl);
+        let match = name.match(/^(.*)(\d+)$/);
+        let newName;
+        if (!match) {
+          newName = name + '2';
+        } else {
+          newName = match[1] + (parseInt(match[2], 10) + 1);
+        }
+        decl.rename(newName);
+      }
+      declarationNames.add(getDeclName(decl));
       declaration.properties.push(decl);
     });
   }
@@ -465,12 +482,17 @@ function migrateAttributesToPropertiesBlock(polyCall, declaration, attrs) {
             computedPropName + " to be a string.");
       }
       var computedExpression = computedProp.value.value;
-      var fixupResult = fixupComputedExpression(computedPropName, computedExpression);
-      var newComputedExpression = fixupResult[0];
-      var newDeclaration = fixupResult[1];
+      var [namer, newDeclaration] = fixupComputedExpression(computedExpression);
       attrs[computedPropName] = attrs[computedPropName] || {name: computedPropName};
-      attrs[computedPropName].computed = {type: 'Literal', value: newComputedExpression};
+      const renameFn = (name) => {
+        const newComputedExpression = namer(name);
+        attrs[computedPropName].computed = {
+            type: 'Literal', value: newComputedExpression};
+      };
+      renameFn('compute' + computedPropName.charAt(0).toUpperCase() +
+          computedPropName.slice(1));
       if (newDeclaration) {
+        newDeclaration.rename = renameFn;
         newComputedFunctions.push(newDeclaration);
       }
     });
@@ -583,11 +605,11 @@ function getBehaviorsDeclaration(behaviors) {
   };
 }
 
-function fixupComputedExpression(attrName, expression) {
-  var functionExpression = 'function x() { return (' + expression + '); }';
-  var parsed = espree.parse(functionExpression);
+function fixupComputedExpression(expression) {
+  const functionExpression = 'function x() { return (' + expression + '); }';
+  let parsed = espree.parse(functionExpression);
   parsed = parsed.body[0].body.body[0].argument;
-  var leadingComments = [];
+  const leadingComments = [];
 
   function isObservable(astNode) {
     if (astNode.type === 'Identifier') {
@@ -616,7 +638,7 @@ function fixupComputedExpression(attrName, expression) {
   // An expression that's just an identifier or member expression, or that's
   // a simple function call on the same can be left as it is.
   if (isObservable(parsed)) {
-    return [expression, null];
+    return [() => expression, null];
   }
   if (parsed.type === 'CallExpression') {
     var allArgumentsAreObservable = true;
@@ -625,7 +647,7 @@ function fixupComputedExpression(attrName, expression) {
           allArgumentsAreObservable && isObservable(arg));
     });
     if (allArgumentsAreObservable) {
-      return [expression, null];
+      return [() => expression, null];
     }
   }
 
@@ -662,13 +684,10 @@ function fixupComputedExpression(attrName, expression) {
   var computedIdentifiers = computedArgs.map(function(argName) {
     return {type: 'Identifier', name: argName};
   });
-  var externalComputedFunctionName = 'compute' +
-      attrName.charAt(0).toUpperCase() + attrName.substring(1);
-  externalComputedFunctionName = externalComputedFunctionName.replace(
-      '$', '').replace('?', '');
+
   var declarationOfExpressionFunction = {
     type: 'Property',
-    key: {type: 'Identifier', name: externalComputedFunctionName},
+    key: {type: 'Identifier', name: 'placeholderMustCallRename'},
     value: {
       type: 'FunctionExpression', id: null, params: computedIdentifiers,
       body: {
@@ -685,15 +704,21 @@ function fixupComputedExpression(attrName, expression) {
       type: 'ExpressionStatement',
       expression: {
         type: 'CallExpression',
-        callee: {type: 'Identifier', name: externalComputedFunctionName},
+        callee: {type: 'Identifier', name: 'placeholderMustCallRename'},
         arguments: computedIdentifiers
       }
     }]
   };
-  var newExpression = escodegen.generate(
+
+  function nameComputedFunction(name) {
+    declarationOfExpressionFunction.key.name = name;
+    newExpressionAst.body[0].expression.callee.name = name;
+    return escodegen.generate(
       newExpressionAst,
       {format: {indent: { style: ''}, newline: ' ', semicolons: false}});
-  return [newExpression, declarationOfExpressionFunction];
+  }
+
+  return [nameComputedFunction, declarationOfExpressionFunction];
 }
 
 module.exports = upgradeJs;

--- a/test/fixtures/data-binding.html
+++ b/test/fixtures/data-binding.html
@@ -4,5 +4,7 @@
   <template>
     <div id='{{x | f}}'></div>
     {{a+b | myFilter(2) | tokenList}}
+    <div title='{{2 * 2}}'></div>
+    <div title='{{4 * 4}}'></div>
   </template>
 </polymer-element>

--- a/test/fixtures/data-binding.html.out
+++ b/test/fixtures/data-binding.html.out
@@ -4,11 +4,19 @@
   <template>
     <div id="{{f(x)}}"></div>
     <span>{{computeExpression1(a, b)}}</span>
+    <div title="{{computeTitle()}}"></div>
+    <div title="{{computeTitle2()}}"></div>
   </template>
 </dom-module>
 <script>
   Polymer({
     is: 'data-binding-test-element',
+    computeTitle: function () {
+      return 2 * 2;
+    },
+    computeTitle2: function () {
+      return 4 * 4;
+    },
     computeExpression1: function (a, b) {
       return this.tokenList(this.myFilter(a + b, 2));
     }


### PR DESCRIPTION
Fixes #30

More complicated than it looks beacuse we only find out about name clashes
very late in the process, but we need to update all references. So I taught new
function declarations how to rename themselves.
