### PR TITLE
Upgrade some one-time bindings to one-way ones.

### DIFF
--- a/lib/upgrade_html.js
+++ b/lib/upgrade_html.js
@@ -342,7 +342,7 @@ class Page {
         newDeclarations.push(declaration);
       } else {
         this.insertHtmlCommentBefore(node, [
-          `The expression {{${expression}}} can't work in a`,
+          `The expression   ${expression}   can't work in a`,
           'dom-bind template, as it should be an anonymous computed property.',
           'If you convert it into a Polymer element then polyup should be ' +
           'able to',
@@ -380,7 +380,7 @@ class Page {
         }
         // Join the expressions and their in-between string bits into a single
         // string concat expression.
-        let expressions = [];
+        const expressions = [];
         for (let piece of pieces) {
           if ('string' in piece) {
             expressions.push(escodegen.generate({
@@ -389,6 +389,7 @@ class Page {
             expressions.push(piece.expression);
           }
         }
+        const shouldOneWayBind = pieces.length === 1 && pieces[0].isOneTime;
         let expression = expressions.join(' + ');
 
         if (shouldConvertToAttributeBinding(attrName, node)) {
@@ -405,7 +406,11 @@ class Page {
         if (newDeclarations && newDeclaration) {
           newDeclaration.rename = (newName) => {
             const newExpression = namer(newName);
-            node.attribs[attrName] = `{{${newExpression}}}`;
+            let expr = `{{${newExpression}}}`;
+            if (shouldOneWayBind) {
+              expr = `[[${newExpression}]]`;
+            }
+            node.attribs[attrName] = expr;
           };
           let computedFunctionName = 'compute' +
               attrName.charAt(0).toUpperCase() + attrName.substring(1);
@@ -413,7 +418,11 @@ class Page {
               '$', '').replace('?', '');
           newDeclaration.rename(computedFunctionName);
         } else {
-          node.attribs[attrName] = `{{${expression}}}`;
+          let expr = `{{${expression}}}`;
+          if (shouldOneWayBind) {
+            expr = `[[${expression}]]`;
+          }
+          node.attribs[attrName] = expr;
         }
       }
     });
@@ -485,7 +494,11 @@ class Page {
 
   matchExpressions(str) {
     function matchFirstExpression(str) {
-      let match = str.match(/\{\{(.+?)\}\}/);
+      let match = str.match(/\[\[(.+?)\]\]/);
+      const isOneTime = !!match;
+      if (!match) {
+        match = str.match(/\{\{(.+?)\}\}/);
+      }
       if (!match) {
         return null;
       }
@@ -502,7 +515,7 @@ class Page {
       }
       let leadingString = str.substring(0, match.index);
       let trailingString = str.substring(match.index + match[0].length);
-      return {leadingString, expression, trailingString};
+      return {leadingString, expression, trailingString, isOneTime};
     }
     var pieces = [];
     while(true) {
@@ -513,11 +526,11 @@ class Page {
         }
         break;
       }
-      let {leadingString, expression, trailingString} = matched;
+      let {leadingString, expression, trailingString, isOneTime} = matched;
       if (leadingString) {
         pieces.push({string: leadingString});
       }
-      pieces.push({expression: expression});
+      pieces.push({expression: expression, isOneTime});
       str = trailingString;
     }
     return pieces;

--- a/test/fixtures/data-binding.html
+++ b/test/fixtures/data-binding.html
@@ -6,5 +6,10 @@
     {{a+b | myFilter(2) | tokenList}}
     <div title='{{2 * 2}}'></div>
     <div title='{{4 * 4}}'></div>
+    <div title='[[x]]'></div>
+    <div title='[[8 * 8]]'></div>
+    <div title='[[x]] is the new [[y]]'></div>
+    <div title='[[y]] is the new {{z}}'></div>
+    [[x]]
   </template>
 </polymer-element>

--- a/test/fixtures/data-binding.html.out
+++ b/test/fixtures/data-binding.html.out
@@ -6,6 +6,11 @@
     <span>{{computeExpression1(a, b)}}</span>
     <div title="{{computeTitle()}}"></div>
     <div title="{{computeTitle2()}}"></div>
+    <div title="[[x]]"></div>
+    <div title="[[computeTitle3()]]"></div>
+    <div title="{{computeTitle4(x, y)}}"></div>
+    <div title="{{computeTitle5(y, z)}}"></div>
+    <span>{{x}}</span>
   </template>
   <script>
     Polymer({
@@ -15,6 +20,15 @@
       },
       computeTitle2: function () {
         return 4 * 4;
+      },
+      computeTitle3: function () {
+        return 8 * 8;
+      },
+      computeTitle4: function (x, y) {
+        return x + ' is the new ' + y;
+      },
+      computeTitle5: function (y, z) {
+        return y + ' is the new ' + z;
       },
       computeExpression1: function (a, b) {
         return this.tokenList(this.myFilter(a + b, 2));

--- a/test/fixtures/template-auto-bind.html.out
+++ b/test/fixtures/template-auto-bind.html.out
@@ -14,7 +14,7 @@
     User says: <span>{{greeting}}</span>
   </div>
   <!--
-      The expression {{greeting + " world"}} can't work in a
+      The expression   greeting + " world"   can't work in a
       dom-bind template, as it should be an anonymous computed property.
       If you convert it into a Polymer element then polyup should be able to
       upgrade it.


### PR DESCRIPTION
The only time it makes sense is when binding directly to
attributes, as that's the only time that the binding could
be bidirectional. A 0.5 one-time binding is also one-directional,
so in that case we should keep the [[foo]] syntax to preserve
that intent.

Fixes #40
