### PR TITLE
obj[keyStr] as a computed expression depends on keyStr

### DIFF
--- a/lib/upgrade_js.js
+++ b/lib/upgrade_js.js
@@ -696,7 +696,8 @@ function fixupComputedExpression(expression) {
         }
         // If the identifier is the 'bar' in an expression like `foo.bar`, then
         // we don't consider it an input identifier. Only foo should be counted.
-        if (parent && parent.type === 'MemberExpression' && parent.property === node) {
+        if (parent && parent.type === 'MemberExpression' &&
+            !parent.computed && parent.property === node) {
           return;
         }
         inputIdentifiers.add(node.name);

--- a/test/fixtures/data-binding.html
+++ b/test/fixtures/data-binding.html
@@ -8,6 +8,7 @@
     <div title='{{4 * 4}}'></div>
     <div title='[[x]]'></div>
     <div title='[[8 * 8]]'></div>
+    <div title='{{x[y]}}'></div>
     <div title='[[x]] is the new [[y]]'></div>
     <div title='[[y]] is the new {{z}}'></div>
     [[x]]

--- a/test/fixtures/data-binding.html.out
+++ b/test/fixtures/data-binding.html.out
@@ -9,7 +9,8 @@
     <div title="[[x]]"></div>
     <div title="[[computeTitle3()]]"></div>
     <div title="{{computeTitle4(x, y)}}"></div>
-    <div title="{{computeTitle5(y, z)}}"></div>
+    <div title="{{computeTitle5(x, y)}}"></div>
+    <div title="{{computeTitle6(y, z)}}"></div>
     <span>{{x}}</span>
   </template>
   <script>
@@ -25,9 +26,12 @@
         return 8 * 8;
       },
       computeTitle4: function (x, y) {
+        return x[y];
+      },
+      computeTitle5: function (x, y) {
         return x + ' is the new ' + y;
       },
-      computeTitle5: function (y, z) {
+      computeTitle6: function (y, z) {
         return y + ' is the new ' + z;
       },
       computeExpression1: function (a, b) {


### PR DESCRIPTION
Fixes #54
