### PR TITLE
Add var to for loop's key variable in tokenList.

### DIFF
--- a/lib/upgrade_js.js
+++ b/lib/upgrade_js.js
@@ -232,7 +232,7 @@ class Script {
       const ast = espree.parse(`
         (function (obj) {
           var pieces = [];
-          for (key in obj) {
+          for (var key in obj) {
             if (obj[key]) {
               pieces.push(key);
             }


### PR DESCRIPTION
Without 'var' a global is created, which is bad and fails 'grunt inlinelint'.